### PR TITLE
Update to v5.0.3, and match work done in https://github.com/Asana/cod…

### DIFF
--- a/fibers.js
+++ b/fibers.js
@@ -85,46 +85,21 @@ function setupAsyncHacks(Fiber) {
 			}
 		}
 
-		function logUsingFibers(fibersMethod) {
-			const logUseFibersLevel = +(process.env.ENABLE_LOG_USE_FIBERS || 0);
-
-			if (!logUseFibersLevel) return;
-
-			if (logUseFibersLevel === 1) {
-				console.warn(`[FIBERS_LOG] Using ${fibersMethod}.`);
-				return;
-			}
-
-			const { LOG_USE_FIBERS_INCLUDE_IN_PATH } = process.env;
-			const stackFromError = new Error(`[FIBERS_LOG] Using ${fibersMethod}.`).stack;
-
-			if (
-				!LOG_USE_FIBERS_INCLUDE_IN_PATH ||
-				stackFromError.includes(LOG_USE_FIBERS_INCLUDE_IN_PATH)
-			) {
-				console.warn(stackFromError);
-			}
-		}
-
-		function wrapFunction(fn, fibersMethod) {
-			return function () {
-				logUsingFibers(fibersMethod);
+		function wrapFunction(fn) {
+			return function() {
 				var stack = getAndClearStack();
 				try {
 					return fn.apply(this, arguments);
 				} finally {
 					restoreStack(stack);
 				}
-			};
+			}
 		}
 
 		// Monkey patch methods which may long jump
-		Fiber.yield = wrapFunction(Fiber.yield, "Fiber.yield");
-		Fiber.prototype.run = wrapFunction(Fiber.prototype.run, "Fiber.run");
-		Fiber.prototype.throwInto = wrapFunction(
-			Fiber.prototype.throwInto,
-			"Fiber.throwInto"
-		);
+		Fiber.yield = wrapFunction(Fiber.yield);
+		Fiber.prototype.run = wrapFunction(Fiber.prototype.run);
+		Fiber.prototype.throwInto = wrapFunction(Fiber.prototype.throwInto);
 
 	} catch (err) {
 		return;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "fibers",
-	"version": "5.0.2",
+	"version": "5.0.3",
 	"description": "Cooperative multi-tasking for Javascript",
 	"keywords": [
 		"fiber",


### PR DESCRIPTION
…ez/pull/233007.

This updates to v5.0.3, which is the most recent NPM version of fibers. Notably, the most recent version of fibers at https://github.com/laverdet/node-fibers appears to be v5.0.2, which I don't understand.

The main change to v5.0.3 is to remove certain logging. The main change in https://github.com/Asana/codez/pull/233007 was to add linux builds against the Node 18, which are included at s3://asana-oss-cache/node-fibers/fibers-5.0.3.tar.gz, but not in this repository.