### PR TITLE
Remove Windows support and simplify architecture targets

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -8,12 +8,6 @@
 					'GCC_OPTIMIZATION_LEVEL': '3',
 					'GCC_GENERATE_DEBUGGING_SYMBOLS': 'NO',
 				},
-				'msvs_settings': {
-					'VCCLCompilerTool': {
-						'Optimization': 3,
-						'FavorSizeOrSpeed': 1,
-					},
-				},
 			}
 		},
 	},
@@ -29,15 +23,9 @@
 				'src/libcoro/coro.h',
 			],
 			'cflags!': ['-ansi'],
+			'defines': ['USE_CORO', 'CORO_GUARDPAGES=1'],
+			'ldflags': ['-pthread'],
 			'conditions': [
-				['OS == "win"',
-					{'defines': ['CORO_FIBER', 'WINDOWS']},
-				# else
-					{
-						'defines': ['USE_CORO', 'CORO_GUARDPAGES=1'],
-						'ldflags': ['-pthread'],
-					}
-				],
 				['OS == "linux"',
 					{
 						'cflags_c': [ '-std=gnu11' ],
@@ -52,16 +40,7 @@
 						],
 					},
 				],
-				['OS == "solaris" or OS == "sunos" or OS == "freebsd" or OS == "aix"', {'defines': ['CORO_UCONTEXT']}],
 				['OS == "mac"', {'defines': ['CORO_ASM']}],
-				['OS == "openbsd"', {'defines': ['CORO_ASM']}],
-				['target_arch == "arm"',
-					{
-						# There's been problems getting real fibers working on arm
-						'defines': ['CORO_PTHREAD'],
-						'defines!': ['CORO_UCONTEXT', 'CORO_SJLJ', 'CORO_ASM'],
-					},
-				],
 				['target_arch == "arm64"',
 					{
 						# There's been problems getting real fibers working on arm

--- a/build.js
+++ b/build.js
@@ -27,7 +27,7 @@ var args = process.argv.slice(2).filter(function(arg) {
 if (!debug) {
 	args.push('--release');
 }
-if (!{ia32: true, x64: true, arm: true, arm64: true, ppc: true, ppc64: true, s390: true, s390x: true}.hasOwnProperty(arch)) {
+if (!{x64: true, arm64: true}.hasOwnProperty(arch)) {
 	console.error('Unsupported (?) architecture: `'+ arch+ '`');
 	process.exit(1);
 }

--- a/build.js
+++ b/build.js
@@ -60,7 +60,7 @@ function build() {
 		args.push('--target='+ process.versions.electron,  '--dist-url=https://atom.io/download/atom-shell');
 	}
 	cp.spawn(
-		process.platform === 'win32' ? 'node-gyp.cmd' : 'node-gyp',
+		'node-gyp',
 		['rebuild'].concat(args),
 		{stdio: [process.stdin, process.stdout, process.stderr]})
 	.on('exit', function(err) {

--- a/src/coroutine.cc
+++ b/src/coroutine.cc
@@ -1,20 +1,7 @@
 #include "coroutine.h"
 #include "v8-version.h"
 #include <assert.h>
-#ifndef WINDOWS
 #include <pthread.h>
-#else
-#include <windows.h>
-#include <intrin.h>
-// Stub pthreads into Windows approximations
-#define pthread_t HANDLE
-#define pthread_create(thread, attr, fn, arg) !((*thread)=CreateThread(NULL, 0, &(fn), arg, 0, NULL))
-#define pthread_join(thread, arg) WaitForSingleObject((thread), INFINITE)
-#define pthread_key_t DWORD
-#define pthread_key_create(key, dtor) (*key)=TlsAlloc()
-#define pthread_setspecific(key, val) TlsSetValue((key), (val))
-#define pthread_getspecific(key) TlsGetValue((key))
-#endif
 
 #include <stdexcept>
 #include <stack>
@@ -35,19 +22,8 @@ static Coroutine* delete_me = NULL;
 size_t Coroutine::pool_size = 120;
 
 static bool can_poke(void* addr) {
-#ifdef WINDOWS
-	MEMORY_BASIC_INFORMATION mbi;
-	if (!VirtualQueryEx(GetCurrentProcess(), addr, &mbi, sizeof(mbi))) {
-		return false;
-	}
-	if (!(mbi.State & MEM_COMMIT)) {
-		return false;
-	}
-	return true;
-#else
 	// TODO?
 	return addr > (void*)0x1000;
-#endif
 }
 
 #ifdef USE_V8_SYMBOLS
@@ -75,11 +51,8 @@ namespace v8 {
 }
 #endif
 
-#ifndef WINDOWS
+
 static void* find_thread_id_key(void* arg)
-#else
-static DWORD __stdcall find_thread_id_key(LPVOID arg)
-#endif
 {
 	v8::Isolate* isolate = static_cast<v8::Isolate*>(arg);
 	assert(isolate != NULL);
@@ -177,13 +150,6 @@ void Coroutine::trampoline(void* that) {
 #ifdef CORO_PTHREAD
 	pthread_setspecific(coro_thread_key, that);
 #endif
-#ifdef CORO_FIBER
-	// I can't figure out how to get the precise base of the stack in Windows. Since CreateFiber
-	// creates the stack automatically we don't have access to the base. We can however grab the
-	// current esp position, and use that as an approximation. Padding is added for safety since the
-	// base is slightly different.
-	static_cast<Coroutine*>(that)->stack_base = (size_t*)_AddressOfReturnAddress() - stack_size + 16;
-#endif
 	if (!fls_data_pool.empty()) {
 		pthread_setspecific(thread_data_key, fls_data_pool.back());
 		pthread_setspecific(thread_id_key, fls_data_pool[fls_data_pool.size() - 2]);
@@ -213,9 +179,6 @@ Coroutine::~Coroutine() {
 	if (stack.sptr) {
 		coro_stack_free(&stack);
 	}
-#ifdef CORO_FIBER
-	if (context.fiber)
-#endif
 	(void)coro_destroy(&context);
 }
 
@@ -232,17 +195,6 @@ Coroutine* Coroutine::create_fiber(entry_t* entry, void* arg) {
 		return NULL;
 	}
 	coro_create(&coro->context, trampoline, coro, coro->stack.sptr, coro->stack.ssze);
-#ifdef CORO_FIBER
-	// Stupid hack. libcoro's project structure combined with Windows's CreateFiber functions makes
-	// it difficult to catch this error. Sometimes Windows will return `ERROR_NOT_ENOUGH_MEMORY` or
-	// `ERROR_COMMITMENT_LIMIT` if it can't make any more fibers. However, `coro_stack_alloc` returns
-	// success unconditionally on Windows so we have to detect the error here, after the call to
-	// `coro_create`.
-	if (!coro->context.fiber) {
-		delete coro;
-		return NULL;
-	}
-#endif
 	++coroutines_created_;
 	return coro;
 }
@@ -315,11 +267,7 @@ void Coroutine::finish(Coroutine& next, v8::Isolate* isolate) {
 }
 
 void* Coroutine::bottom() const {
-#ifdef CORO_FIBER
-	return stack_base;
-#else
 	return stack.sptr;
-#endif
 }
 
 size_t Coroutine::size() const {

--- a/src/coroutine.h
+++ b/src/coroutine.h
@@ -8,9 +8,6 @@ class Coroutine {
 		typedef void(entry_t)(void*);
 
 	private:
-#ifdef CORO_FIBER
-		void* stack_base;
-#endif
 		coro_context context;
 		coro_stack stack;
 		std::vector<void*> fls_data;

--- a/src/libcoro/coro.c
+++ b/src/libcoro/coro.c
@@ -46,21 +46,14 @@
 /*****************************************************************************/
 /* ucontext/setjmp/asm backends                                              */
 /*****************************************************************************/
-#if CORO_UCONTEXT || CORO_SJLJ || CORO_LOSER || CORO_LINUX || CORO_IRIX || CORO_ASM
+#if CORO_UCONTEXT || CORO_SJLJ || CORO_LINUX || CORO_ASM
 
 # if CORO_UCONTEXT
 #  include <stddef.h>
 # endif
 
 # if !defined(STACK_ADJUST_PTR)
-#  if __sgi
-/* IRIX is decidedly NON-unix */
-#   define STACK_ADJUST_PTR(sp,ss) ((char *)(sp) + (ss) - 8)
-#   define STACK_ADJUST_SIZE(sp,ss) ((ss) - 8)
-#  elif (__i386__ && CORO_LINUX) || (_M_IX86 && CORO_LOSER)
-#   define STACK_ADJUST_PTR(sp,ss) ((char *)(sp) + (ss))
-#   define STACK_ADJUST_SIZE(sp,ss) (ss)
-#  elif (__amd64__ && CORO_LINUX) || ((_M_AMD64 || _M_IA64) && CORO_LOSER)
+#  if (__amd64__ && CORO_LINUX)
 #   define STACK_ADJUST_PTR(sp,ss) ((char *)(sp) + (ss) - 8)
 #   define STACK_ADJUST_SIZE(sp,ss) (ss)
 #  else
@@ -117,76 +110,16 @@ trampoline (int sig)
 
 # if CORO_ASM
 
-  #if _WIN32 || __CYGWIN__
-    #define CORO_WIN_TIB 1
-  #endif
-
   asm (
        "\t.text\n"
-       #if _WIN32 || __CYGWIN__ || __APPLE__
+       #if __APPLE__
        "\t.globl _coro_transfer\n"
        "_coro_transfer:\n"
        #else
        "\t.globl coro_transfer\n"
        "coro_transfer:\n"
        #endif
-       /* windows, of course, gives a shit on the amd64 ABI and uses different registers */
-       /* http://blogs.msdn.com/freik/archive/2005/03/17/398200.aspx */
        #if __amd64
-
-         #if _WIN32 || __CYGWIN__
-           #define NUM_SAVED 29
-           "\tsubq $168, %rsp\t" /* one dummy qword to improve alignment */
-           "\tmovaps %xmm6, (%rsp)\n"
-           "\tmovaps %xmm7, 16(%rsp)\n"
-           "\tmovaps %xmm8, 32(%rsp)\n"
-           "\tmovaps %xmm9, 48(%rsp)\n"
-           "\tmovaps %xmm10, 64(%rsp)\n"
-           "\tmovaps %xmm11, 80(%rsp)\n"
-           "\tmovaps %xmm12, 96(%rsp)\n"
-           "\tmovaps %xmm13, 112(%rsp)\n"
-           "\tmovaps %xmm14, 128(%rsp)\n"
-           "\tmovaps %xmm15, 144(%rsp)\n"
-           "\tpushq %rsi\n"
-           "\tpushq %rdi\n"
-           "\tpushq %rbp\n"
-           "\tpushq %rbx\n"
-           "\tpushq %r12\n"
-           "\tpushq %r13\n"
-           "\tpushq %r14\n"
-           "\tpushq %r15\n"
-           #if CORO_WIN_TIB
-             "\tpushq %fs:0x0\n"
-             "\tpushq %fs:0x8\n"
-             "\tpushq %fs:0xc\n"
-           #endif
-           "\tmovq %rsp, (%rcx)\n"
-           "\tmovq (%rdx), %rsp\n"
-           #if CORO_WIN_TIB
-             "\tpopq %fs:0xc\n"
-             "\tpopq %fs:0x8\n"
-             "\tpopq %fs:0x0\n"
-           #endif
-           "\tpopq %r15\n"
-           "\tpopq %r14\n"
-           "\tpopq %r13\n"
-           "\tpopq %r12\n"
-           "\tpopq %rbx\n"
-           "\tpopq %rbp\n"
-           "\tpopq %rdi\n"
-           "\tpopq %rsi\n"
-           "\tmovaps (%rsp), %xmm6\n"
-           "\tmovaps 16(%rsp), %xmm7\n"
-           "\tmovaps 32(%rsp), %xmm8\n"
-           "\tmovaps 48(%rsp), %xmm9\n"
-           "\tmovaps 64(%rsp), %xmm10\n"
-           "\tmovaps 80(%rsp), %xmm11\n"
-           "\tmovaps 96(%rsp), %xmm12\n"
-           "\tmovaps 112(%rsp), %xmm13\n"
-           "\tmovaps 128(%rsp), %xmm14\n"
-           "\tmovaps 144(%rsp), %xmm15\n"
-           "\taddq $168, %rsp\n"
-         #else
            #define NUM_SAVED 6
            "\tpushq %rbp\n"
            "\tpushq %rbx\n"
@@ -202,38 +135,9 @@ trampoline (int sig)
            "\tpopq %r12\n"
            "\tpopq %rbx\n"
            "\tpopq %rbp\n"
-         #endif
+
          "\tpopq %rcx\n"
          "\tjmpq *%rcx\n"
-
-       #elif __i386
-
-         #define NUM_SAVED 4
-         "\tpushl %ebp\n"
-         "\tpushl %ebx\n"
-         "\tpushl %esi\n"
-         "\tpushl %edi\n"
-         #if CORO_WIN_TIB
-           #undef NUM_SAVED
-           #define NUM_SAVED 7
-           "\tpushl %fs:0\n"
-           "\tpushl %fs:4\n"
-           "\tpushl %fs:8\n"
-         #endif
-         "\tmovl %esp, (%eax)\n"
-         "\tmovl (%edx), %esp\n"
-         #if CORO_WIN_TIB
-           "\tpopl %fs:8\n"
-           "\tpopl %fs:4\n"
-           "\tpopl %fs:0\n"
-         #endif
-         "\tpopl %edi\n"
-         "\tpopl %esi\n"
-         "\tpopl %ebx\n"
-         "\tpopl %ebp\n"
-         "\tpopl %ecx\n"
-         "\tjmpl *%ecx\n"
-
        #else
          #error unsupported architecture
        #endif
@@ -310,31 +214,6 @@ coro_create (coro_context *ctx, coro_func coro, void *arg, void *sptr, size_t ss
   sigaction (SIGUSR2, &osa, 0);
   sigprocmask (SIG_SETMASK, &osig, 0);
 
-# elif CORO_LOSER
-
-  coro_setjmp (ctx->env);
-  #if __CYGWIN__ && __i386
-    ctx->env[8]                        = (long)    coro_init;
-    ctx->env[7]                        = (long)    ((char *)sptr + ssize)         - sizeof (long);
-  #elif __CYGWIN__ && __x86_64
-    ctx->env[7]                        = (long)    coro_init;
-    ctx->env[6]                        = (long)    ((char *)sptr + ssize)         - sizeof (long);
-  #elif defined __MINGW32__
-    ctx->env[5]                        = (long)    coro_init;
-    ctx->env[4]                        = (long)    ((char *)sptr + ssize)         - sizeof (long);
-  #elif defined _M_IX86
-    ((_JUMP_BUFFER *)&ctx->env)->Eip   = (long)    coro_init;
-    ((_JUMP_BUFFER *)&ctx->env)->Esp   = (long)    STACK_ADJUST_PTR (sptr, ssize) - sizeof (long);
-  #elif defined _M_AMD64
-    ((_JUMP_BUFFER *)&ctx->env)->Rip   = (__int64) coro_init;
-    ((_JUMP_BUFFER *)&ctx->env)->Rsp   = (__int64) STACK_ADJUST_PTR (sptr, ssize) - sizeof (__int64);
-  #elif defined _M_IA64
-    ((_JUMP_BUFFER *)&ctx->env)->StIIP = (__int64) coro_init;
-    ((_JUMP_BUFFER *)&ctx->env)->IntSp = (__int64) STACK_ADJUST_PTR (sptr, ssize) - sizeof (__int64);
-  #else
-    #error "microsoft libc or architecture not supported"
-  #endif
-
 # elif CORO_LINUX
 
   coro_setjmp (ctx->env);
@@ -344,9 +223,6 @@ coro_create (coro_context *ctx, coro_func coro, void *arg, void *sptr, size_t ss
   #elif __GLIBC__ >= 2 && __GLIBC_MINOR__ >= 0 && defined (__mc68000__)
     ctx->env[0].__jmpbuf[0].__aregs[0] = (long int)coro_init;
     ctx->env[0].__jmpbuf[0].__sp       = (int *)   ((char *)sptr + ssize)         - sizeof (long);
-  #elif defined (__GNU_LIBRARY__) && defined (__i386__)
-    ctx->env[0].__jmpbuf[0].__pc       = (char *)  coro_init;
-    ctx->env[0].__jmpbuf[0].__sp       = (void *)  ((char *)sptr + ssize)         - sizeof (long);
   #elif defined (__GNU_LIBRARY__) && defined (__amd64__)
     ctx->env[0].__jmpbuf[JB_PC]        = (long)    coro_init;
     ctx->env[0].__jmpbuf[0].__sp       = (void *)  ((char *)sptr + ssize)         - sizeof (long);
@@ -354,23 +230,11 @@ coro_create (coro_context *ctx, coro_func coro, void *arg, void *sptr, size_t ss
     #error "linux libc or architecture not supported"
   #endif
 
-# elif CORO_IRIX
-
-  coro_setjmp (ctx->env, 0);
-  ctx->env[JB_PC]                      = (__uint64_t)coro_init;
-  ctx->env[JB_SP]                      = (__uint64_t)STACK_ADJUST_PTR (sptr, ssize) - sizeof (long);
-
 # elif CORO_ASM
 
   ctx->sp = (void **)(ssize + (char *)sptr);
   *--ctx->sp = (void *)abort; /* needed for alignment only */
   *--ctx->sp = (void *)coro_init;
-
-  #if CORO_WIN_TIB
-  *--ctx->sp = 0;                    /* ExceptionList */
-  *--ctx->sp = (char *)sptr + ssize; /* StackBase */
-  *--ctx->sp = sptr;                 /* StackLimit */
-  #endif
 
   ctx->sp -= NUM_SAVED;
   memset (ctx->sp, 0, sizeof (*ctx->sp) * NUM_SAVED);
@@ -438,9 +302,6 @@ coro_transfer (coro_context *prev, coro_context *next)
 {
   pthread_cond_signal (&next->cv);
   pthread_cond_wait (&prev->cv, &coro_mutex);
-#if __FreeBSD__ /* freebsd is of course broken and needs manual testcancel calls... yay... */
-  pthread_testcancel ();
-#endif
 }
 
 void
@@ -474,9 +335,6 @@ coro_create (coro_context *ctx, coro_func coro, void *arg, void *sptr, size_t ss
 #if __UCLIBC__
       /* exists, but is borked */
       /*pthread_attr_setstacksize (&attr, (size_t)ssize);*/
-#elif __CYGWIN__
-      /* POSIX, not here */
-      pthread_attr_setstacksize (&attr, (size_t)ssize);
 #else
       pthread_attr_setstack (&attr, sptr, (size_t)ssize);
 #endif
@@ -503,59 +361,6 @@ coro_destroy (coro_context *ctx)
   pthread_cond_destroy (&ctx->cv);
 }
 
-/*****************************************************************************/
-/* fiber backend                                                             */
-/*****************************************************************************/
-#elif CORO_FIBER
-
-#define WIN32_LEAN_AND_MEAN
-#if _WIN32_WINNT < 0x0400
-  #undef _WIN32_WINNT
-  #define _WIN32_WINNT 0x0400
-#endif
-#include <windows.h>
-
-VOID CALLBACK
-coro_init (PVOID arg)
-{
-  coro_context *ctx = (coro_context *)arg;
-
-  ctx->coro (ctx->arg);
-}
-
-void
-coro_transfer (coro_context *prev, coro_context *next)
-{
-  if (!prev->fiber)
-    {
-      prev->fiber = GetCurrentFiber ();
-
-      if (prev->fiber == 0 || prev->fiber == (void *)0x1e00)
-        prev->fiber = ConvertThreadToFiber (0);
-    }
-
-  SwitchToFiber (next->fiber);
-}
-
-void
-coro_create (coro_context *ctx, coro_func coro, void *arg, void *sptr, size_t ssize)
-{
-  ctx->fiber = 0;
-  ctx->coro  = coro;
-  ctx->arg   = arg;
-
-  if (!coro)
-    return;
-
-  ctx->fiber = CreateFiber (ssize, coro_init, ctx);
-}
-
-void
-coro_destroy (coro_context *ctx)
-{
-  DeleteFiber (ctx->fiber);
-}
-
 #else
   #error unsupported backend
 #endif
@@ -566,10 +371,8 @@ coro_destroy (coro_context *ctx)
 #if CORO_STACKALLOC
 
 #include <stdlib.h>
+#include <unistd.h>
 
-#ifndef _WIN32
-# include <unistd.h>
-#endif
 
 #if CORO_USE_VALGRIND
 # include <valgrind/valgrind.h>
@@ -602,7 +405,7 @@ coro_destroy (coro_context *ctx)
 # undef CORO_GUARDPAGES
 #endif
 
-#if !__i386 && !__x86_64 && !__powerpc && !__m68k && !__alpha && !__mips && !__sparc64
+#if !__x86_64 && !__powerpc && !__m68k && !__alpha && !__mips && !__sparc64
 # undef CORO_GUARDPAGES
 #endif
 
@@ -638,21 +441,11 @@ coro_stack_alloc (struct coro_stack *stack, unsigned int size)
   stack->sptr = 0;
   stack->ssze = ((size_t)size * sizeof (void *) + PAGESIZE - 1) / PAGESIZE * PAGESIZE;
 
-#if CORO_FIBER
-
-  stack->sptr = (void *)stack;
-  return 1;
-
-#else
-
   size_t ssze = stack->ssze + CORO_GUARDPAGES * PAGESIZE;
   void *base;
 
   #if CORO_MMAP
     int mflags = MAP_PRIVATE | MAP_ANONYMOUS;
-  #if defined(__OpenBSD__) || defined(__FreeBSD__)
-    mflags |= MAP_STACK;
-  #endif
     /* mmap supposedly does allocate-on-write for us */
     base = mmap (0, ssze, PROT_READ | PROT_WRITE, mflags, -1, 0);
 
@@ -678,16 +471,11 @@ coro_stack_alloc (struct coro_stack *stack, unsigned int size)
 
   stack->sptr = base;
   return 1;
-
-#endif
 }
 
 void
 coro_stack_free (struct coro_stack *stack)
 {
-#if CORO_FIBER
-  /* nop */
-#else
   #if CORO_USE_VALGRIND
     VALGRIND_STACK_DEREGISTER (stack->valgrind_id);
   #endif
@@ -699,7 +487,6 @@ coro_stack_free (struct coro_stack *stack)
   #else
     free (stack->sptr);
   #endif
-#endif
 }
 
 #endif

--- a/src/libcoro/coro.h
+++ b/src/libcoro/coro.h
@@ -119,24 +119,6 @@ extern "C" {
  *    (it is very fast and therefore recommended over other methods, but
  *    doesn't work with anything newer).
  *
- * -DCORO_LOSER
- *
- *    CORO_SJLJ variant.
- *    Microsoft's highly proprietary platform doesn't support sigaltstack, and
- *    this selects a suitable workaround for this platform. It might not work
- *    with your compiler though - it has only been tested with MSVC 6.
- *
- * -DCORO_FIBER
- *
- *    Slower, but probably more portable variant for the Microsoft operating
- *    system, using fibers. Ignores the passed stack and allocates it internally.
- *    Also, due to bugs in cygwin, this does not work with cygwin.
- *
- * -DCORO_IRIX
- *
- *    CORO_SJLJ variant.
- *    For SGI's version of Microsoft's NT ;)
- *
  * -DCORO_ASM
  *
  *    Hand coded assembly, known to work only on a few architectures/ABI:
@@ -295,26 +277,13 @@ void coro_stack_free (struct coro_stack *stack);
 
 /*****************************************************************************/
 
-#if !defined CORO_LOSER      && !defined CORO_UCONTEXT \
-    && !defined CORO_SJLJ    && !defined CORO_LINUX \
-    && !defined CORO_IRIX    && !defined CORO_ASM \
-    && !defined CORO_PTHREAD && !defined CORO_FIBER
-# if defined WINDOWS && (defined __i386 || (__x86_64 || defined _M_IX86 || defined _M_AMD64)
-#  define CORO_ASM 1
-# elif defined WINDOWS || defined _WIN32
-#  define CORO_LOSER 1 /* you don't win with windoze */
-# elif __linux && (__i386 || (__x86_64 && !__ILP32))
-#  define CORO_ASM 1
-# elif __APPLE__ && (__i386 || (__x86_64 && !__ILP32))
-#  define CORO_ASM 1
-# elif defined HAVE_UCONTEXT_H
-#  define CORO_UCONTEXT 1
-# elif defined HAVE_SETJMP_H && defined HAVE_SIGALTSTACK
-#  define CORO_SJLJ 1
-# else
+#if !defined CORO_UCONTEXT \
+    && !defined CORO_SJLJ \
+    && !defined CORO_LINUX \
+    && !defined CORO_ASM \
+    && !defined CORO_PTHREAD
 error unknown or unsupported architecture
 # endif
-#endif
 
 /*****************************************************************************/
 
@@ -330,32 +299,20 @@ struct coro_context
 # define coro_transfer(p,n) swapcontext (&((p)->uc), &((n)->uc))
 # define coro_destroy(ctx) (void *)(ctx)
 
-#elif CORO_SJLJ || CORO_LOSER || CORO_LINUX || CORO_IRIX
+#elif CORO_SJLJ || CORO_LINUX
 
 # if defined(CORO_LINUX) && !defined(_GNU_SOURCE)
 #  define _GNU_SOURCE /* for glibc */
 # endif
 
-# if !CORO_LOSER
-#  include <unistd.h>
-# endif
 
-/* solaris is hopelessly borked, it expands _XOPEN_UNIX to nothing */
-# if __sun
-#  undef _XOPEN_UNIX
-#  define _XOPEN_UNIX 1
-# endif
-
+# include <unistd.h>
 # include <setjmp.h>
 
 # if _XOPEN_UNIX > 0 || defined (_setjmp)
 #  define coro_jmp_buf      jmp_buf
 #  define coro_setjmp(env)  _setjmp (env)
 #  define coro_longjmp(env) _longjmp ((env), 1)
-# elif CORO_LOSER
-#  define coro_jmp_buf      jmp_buf
-#  define coro_setjmp(env)  setjmp (env)
-#  define coro_longjmp(env) longjmp ((env), 1)
 # else
 #  define coro_jmp_buf      sigjmp_buf
 #  define coro_setjmp(env)  sigsetjmp (env, 0)
@@ -392,19 +349,6 @@ struct coro_context
 {
   pthread_cond_t cv;
   pthread_t id;
-};
-
-void coro_transfer (coro_context *prev, coro_context *next);
-void coro_destroy (coro_context *ctx);
-
-#elif CORO_FIBER
-
-struct coro_context
-{
-  void *fiber;
-  /* only used for initialisation */
-  coro_func coro;
-  void *arg;
 };
 
 void coro_transfer (coro_context *prev, coro_context *next);

--- a/test/exec.js
+++ b/test/exec.js
@@ -1,14 +1,11 @@
 // gh-1
 var Fiber = require('fibers');
 
-if (process.platform == 'win32') {
-	// There is a problem with running this from a script. Not fibers related.
-	console.log('pass');
-} else {
-	Fiber(function() {
-		require('child_process').exec('echo pass', function(err, stdout) {
-			if (err) console.log(err);
-			process.stdout.write(stdout);
-		});
-	}).run();
-}
+
+Fiber(function() {
+	require('child_process').exec('echo pass', function(err, stdout) {
+		if (err) console.log(err);
+		process.stdout.write(stdout);
+	});
+}).run();
+


### PR DESCRIPTION
Removed Windows and legacy platform support to focus exclusively on x64 and arm64 architectures on Unix-like systems. This eliminates conditional compilation flags, simplifies the codebase, and removes unused code paths.

## Test plan
I tested this and a dependent PR together, by running all the node-fibers tests. `async-hooks.js` failed, but it also failed on master.

So far I have only tested on x64, I will test on arm64 too before merging.