### PR TITLE
Remove legacy V8 API support and electron-specific code

### DIFF
--- a/build.js
+++ b/build.js
@@ -56,9 +56,6 @@ if (!force) {
 
 // Build it
 function build() {
-	if (process.versions.electron) {
-		args.push('--target='+ process.versions.electron,  '--dist-url=https://atom.io/download/atom-shell');
-	}
 	cp.spawn(
 		'node-gyp',
 		['rebuild'].concat(args),
@@ -106,9 +103,4 @@ function afterBuild() {
 	}
 	fs.renameSync(targetPath, installPath);
 	console.log('Installed in `'+ installPath+ '`');
-	if (process.versions.electron) {
-		process.nextTick(function() {
-			require('electron').app.quit();
-		});
-	}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "fibers",
-	"version": "5.0.4",
+	"version": "5.1",
 	"description": "Cooperative multi-tasking for Javascript",
 	"keywords": [
 		"fiber",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "fibers",
-	"version": "5.1",
+	"version": "5.1.0",
 	"description": "Cooperative multi-tasking for Javascript",
 	"keywords": [
 		"fiber",

--- a/src/coroutine.cc
+++ b/src/coroutine.cc
@@ -248,16 +248,8 @@ void Coroutine::finish(Coroutine& next, v8::Isolate* isolate) {
 		if (fiber_pool.size() < pool_size) {
 			fiber_pool.push_back(this);
 		} else {
-#if V8_MAJOR_VERSION > 4 || (V8_MAJOR_VERSION == 4 && V8_MINOR_VERSION >= 10)
 			// Clean up isolate data
 			isolate->DiscardThreadSpecificMetadata();
-#else
-			// If not supported, then we can mitigate v8's leakage by saving these thread locals.
-			fls_data_pool.reserve(fls_data_pool.size() + 3);
-			fls_data_pool.push_back(pthread_getspecific(isolate_key));
-			fls_data_pool.push_back(pthread_getspecific(thread_id_key));
-			fls_data_pool.push_back(pthread_getspecific(thread_data_key));
-#endif
 			// Can't delete right now because we're currently on this stack!
 			assert(delete_me == NULL);
 			delete_me = this;

--- a/src/fibers.cc
+++ b/src/fibers.cc
@@ -261,8 +261,6 @@ class Fiber {
 		 */
 		static void WeakCallback(void* data) {
 			Fiber& that = *static_cast<Fiber*>(data);
-			// Deprecated in 0781f42b6
-			assert(that.handle.IsNearDeath());
 			assert(current != &that);
 
 			// We'll unwind running fibers later... doing it from the garbage collector is bad news.

--- a/src/fibers.cc
+++ b/src/fibers.cc
@@ -14,7 +14,6 @@ using namespace v8;
 
 // Handle legacy V8 API
 namespace uni {
-#if V8_AT_LEAST(5, 3)
 	// Actually 5.2.244
 	// ..or maybe actually 5.2.49
 	template <void (*F)(void*), class P>
@@ -26,38 +25,10 @@ namespace uni {
 	void MakeWeak(Isolate* isolate, Persistent<T>& handle, P* val) {
 		handle.SetWeak(val, WeakCallbackShim<F, P>, WeakCallbackType::kFinalizer);
 	}
-#elif V8_AT_LEAST(3, 26)
-	template <void (*F)(void*), class T, typename P>
-	void WeakCallbackShim(const v8::WeakCallbackData<T, P>& data) {
-		F(data.GetParameter());
-	}
-
-	template <void (*F)(void*), class T, typename P>
-	void MakeWeak(Isolate* isolate, Persistent<T>& handle, P* val) {
-		handle.SetWeak(val, WeakCallbackShim<F>);
-	}
-#else
-	template <void (*F)(void*)>
-	void WeakCallbackShim(Persistent<Value> value, void* data) {
-		F(data);
-	}
-	template <void (*F)(void*), class T, typename P>
-	void MakeWeak(Isolate* isolate, Persistent<T>& handle, P* val) {
-		handle.MakeWeak(val, WeakCallbackShim<F>);
-	}
-#endif
-
-#if V8_AT_LEAST(3, 28)
 	class TryCatch : public v8::TryCatch {
 		public: TryCatch(Isolate* isolate) : v8::TryCatch(isolate) {}
 	};
-#else
-	class TryCatch : public v8::TryCatch {
-		public: TryCatch(Isolate* isolate) : v8::TryCatch() {}
-	};
-#endif
 
-#if V8_AT_LEAST(4, 4)
 	Local<String> NewLatin1String(Isolate* isolate, const char* string) {
 		return String::NewFromOneByte(isolate, (const uint8_t*)string, NewStringType::kNormal).ToLocalChecked();
 	}
@@ -65,25 +36,7 @@ namespace uni {
 	Local<String> NewLatin1Symbol(Isolate* isolate, const char* string) {
 		return String::NewFromOneByte(isolate, (const uint8_t*)string, NewStringType::kNormal).ToLocalChecked();
 	}
-#elif V8_AT_LEAST(3, 26)
-	Handle<String> NewLatin1String(Isolate* isolate, const char* string) {
-		return String::NewFromOneByte(isolate, (const uint8_t*)string);
-	}
 
-	Handle<String> NewLatin1Symbol(Isolate* isolate, const char* string) {
-		return String::NewFromOneByte(isolate, (const uint8_t*)string);
-	}
-#else
-	Handle<String> NewLatin1String(Isolate* isolate, const char* string) {
-		return String::New(string);
-	}
-
-	Handle<String> NewLatin1Symbol(Isolate* isolate, const char* string) {
-		return String::NewSymbol(string);
-	}
-#endif
-
-#if V8_AT_LEAST(4, 4)
 	Local<Function> GetFunction(Local<FunctionTemplate> tmpl) {
 		return tmpl->GetFunction(Isolate::GetCurrent()->GetCurrentContext()).ToLocalChecked();
 	}
@@ -100,54 +53,23 @@ namespace uni {
 	Local<Object> NewInstance(Isolate* isolate, Local<Function> fn, int argc, Local<Value> argv[]) {
 		return fn->NewInstance(isolate->GetCurrentContext(), argc, argv).ToLocalChecked();
 	}
-#else
-	Local<Function> GetFunction(Local<FunctionTemplate> tmpl) {
-		return tmpl->GetFunction();
-	}
 
-	Local<Value> Call(Local<Function> fn, Local<Object> recv, int argc, Local<Value> argv[]) {
-		return fn->Call(recv, argc, argv);
-	}
-
-	Handle<Object> NewInstance(Isolate* isolate, Local<Function> fn, int argc, Local<Value> argv[]) {
-		return fn->NewInstance(argc, argv).ToLocalChecked();
-	}
-#endif
-
-#if V8_AT_LEAST(4, 4)
 	Local<Number> ToNumber(Local<Value> value) {
 		return value->ToNumber(Isolate::GetCurrent()->GetCurrentContext()).ToLocalChecked();
 	}
-#else
-	Handle<Number> ToNumber(Local<Value> value) {
-		return value->ToNumber();
-	}
-#endif
 
-#if V8_AT_LEAST(6, 1)
 	Local<Value> GetStackTrace(TryCatch* try_catch, Local<Context> context) {
 		return try_catch->StackTrace(context).ToLocalChecked();
 	}
-#else
-	Local<Value> GetStackTrace(TryCatch* try_catch, Handle<Context> context) {
-		return try_catch->StackTrace();
-	}
-#endif
 
-// Workaround for v8 issue #1180
-// http://code.google.com/p/v8/issues/detail?id=1180
-// NOTE: it's not clear if this is still necessary (perhaps Isolate::SetStackLimit could be used?)
-#if V8_AT_LEAST(6, 1)
+
+	// Workaround for v8 issue #1180
+	// http://code.google.com/p/v8/issues/detail?id=1180
+	// NOTE: it's not clear if this is still necessary (perhaps Isolate::SetStackLimit could be used?)
 	void fixStackLimit(Isolate* isolate, Local<Context> context) {
 		Script::Compile(context, uni::NewLatin1String(isolate, "void 0;")).ToLocalChecked();
 	}
-#else
-	void fixStackLimit(Isolate* isolate, Handle<Context> context) {
-		Script::Compile(uni::NewLatin1String(isolate, "void 0;"));
-	}
-#endif
 
-#if V8_AT_LEAST(3, 26)
 	// Node v0.11.13+
 	typedef PropertyCallbackInfo<Value> GetterCallbackInfo;
 	typedef PropertyCallbackInfo<void> SetterCallbackInfo;
@@ -250,103 +172,7 @@ namespace uni {
 	void AdjustAmountOfExternalAllocatedMemory(Isolate* isolate, int64_t change_in_bytes) {
 		isolate->AdjustAmountOfExternalAllocatedMemory(change_in_bytes);
 	}
-#else
-	// Node v0.10.x and lower
-	typedef AccessorInfo GetterCallbackInfo;
-	typedef AccessorInfo SetterCallbackInfo;
-	typedef Handle<Value> FunctionType;
-	typedef Arguments Arguments;
 
-	class HandleScope {
-		v8::HandleScope scope;
-		public: HandleScope(Isolate* isolate) {}
-	};
-
-	template <class T>
-	void Reset(Isolate* isolate, Persistent<T>& persistent, Handle<T> handle) {
-		persistent = Persistent<T>::New(handle);
-	}
-	template <class T>
-	void Dispose(Isolate* isolate, Persistent<T>& handle) {
-		handle.Dispose();
-	}
-
-	template <class T>
-	void ClearWeak(Isolate* isolate, Persistent<T>& handle) {
-		handle.ClearWeak();
-	}
-
-	template <class T>
-	void SetInternalPointer(Handle<T> handle, int index, void* val) {
-		handle->SetPointerInInternalField(index, val);
-	}
-	template <class T>
-	void* GetInternalPointer(Handle<T> handle, int index) {
-		return handle->GetPointerFromInternalField(index);
-	}
-
-	template <class T>
-	Handle<T> Deref(Isolate* isolate, Persistent<T>& handle) {
-		return Local<T>::New(handle);
-	}
-
-	Handle<Value> Return(Handle<Value> handle, GetterCallbackInfo info) {
-		return handle;
-	}
-
-	Handle<Value> Return(Handle<Value> handle, const Arguments& args) {
-		return handle;
-	}
-
-	Handle<Value> ThrowException(Isolate* isolate, Handle<Value> exception) {
-		return ThrowException(exception);
-	}
-
-	Handle<Context> GetCurrentContext(Isolate* isolate) {
-		return Context::GetCurrent();
-	}
-
-	Handle<Primitive> Undefined(Isolate* isolate) {
-		return v8::Undefined();
-	}
-
-	Handle<Boolean> NewBoolean(Isolate* isolate, bool value) {
-		return Boolean::New(value);
-	}
-
-	Handle<Number> NewNumber(Isolate* isolate, double value) {
-		return Number::New(value);
-	}
-
-	Handle<FunctionTemplate> NewFunctionTemplate(
-		Isolate* isolate,
-		InvocationCallback callback,
-		Handle<Value> data = Handle<Value>(),
-		Handle<Signature> signature = Handle<Signature>(),
-		int length = 0
-	) {
-		return FunctionTemplate::New(callback, data, signature);
-	}
-
-	Handle<Signature> NewSignature(
-		Isolate* isolate,
-		Handle<FunctionTemplate> receiver = Handle<FunctionTemplate>(),
-		int argc = 0,
-		Handle<FunctionTemplate> argv[] = 0
-	) {
-		return Signature::New(receiver, argc, argv);
-	}
-
-	class ReverseIsolateScope {
-		public: explicit inline ReverseIsolateScope(Isolate* isolate) {}
-	};
-
-	void AdjustAmountOfExternalAllocatedMemory(Isolate* isolate, int64_t change_in_bytes) {
-		V8::AdjustAmountOfExternalAllocatedMemory(change_in_bytes);
-	}
-#endif
-
-#if V8_AT_LEAST(6, 1)
 	void SetAccessor(
 		Isolate* isolate, Local<Object> object, Local<String> name,
 		FunctionType (*getter)(Local<String>, const GetterCallbackInfo&),
@@ -354,45 +180,11 @@ namespace uni {
 	) {
 		object->SetAccessor(isolate->GetCurrentContext(), name, (AccessorNameGetterCallback)getter, (AccessorNameSetterCallback)setter).ToChecked();
 	}
-#elif V8_AT_LEAST(4, 4)
-	void SetAccessor(
-		Isolate* isolate, Local<Object> object, Local<String> name,
-		FunctionType (*getter)(Local<String>, const GetterCallbackInfo&),
-		void (*setter)(Local<String> property, Local<Value> value, const SetterCallbackInfo&) = 0
-	) {
-		object->SetAccessor(isolate->GetCurrentContext(), name, (AccessorNameGetterCallback)getter, (AccessorNameSetterCallback)setter);
-	}
-#else
-	void SetAccessor(
-		Isolate* isolate, Local<Object> object, Local<String> name,
-		FunctionType (*getter)(Local<String>, const GetterCallbackInfo&),
-		void (*setter)(Local<String> property, Local<Value> value, const SetterCallbackInfo&) = 0
-	) {
-		object->SetAccessor(name, (AccessorNameGetterCallback)getter, (AccessorNameSetterCallback)setter);
-	}
-#endif
 
-#if V8_AT_LEAST(3, 29)
 	// This was actually added in 3.29.67
 	void SetStackGuard(Isolate* isolate, void* guard) {
 		isolate->SetStackLimit(reinterpret_cast<uintptr_t>(guard));
 	}
-#elif V8_AT_LEAST(3, 26)
-	void SetStackGuard(Isolate* isolate, void* guard) {
-		ResourceConstraints constraints;
-		constraints.set_stack_limit(reinterpret_cast<uint32_t*>(guard));
-		v8::SetResourceConstraints(isolate, &constraints);
-	}
-#else
-	// Extra padding for old versions of v8. Shit's fucked.
-	void SetStackGuard(Isolate* isolate, void* guard) {
-		ResourceConstraints constraints;
-		constraints.set_stack_limit(
-			reinterpret_cast<uint32_t*>(guard) + 18 * 1024
-		);
-		v8::SetResourceConstraints(&constraints);
-	}
-#endif
 }
 
 class Fiber {
@@ -469,10 +261,8 @@ class Fiber {
 		 */
 		static void WeakCallback(void* data) {
 			Fiber& that = *static_cast<Fiber*>(data);
-#if !V8_AT_LEAST(7, 4)
 			// Deprecated in 0781f42b6
 			assert(that.handle.IsNearDeath());
-#endif
 			assert(current != &that);
 
 			// We'll unwind running fibers later... doing it from the garbage collector is bad news.
@@ -908,9 +698,6 @@ vector<Fiber*> Fiber::orphaned_fibers;
 Persistent<Value> Fiber::fatal_stack;
 bool did_init = false;
 
-#if !NODE_VERSION_AT_LEAST(0,10,0)
-extern "C"
-#endif
 void init(Local<Object> target) {
 	Isolate* isolate = Isolate::GetCurrent();
 	Local<Context> context = isolate->GetCurrentContext();

--- a/src/v8-version.h
+++ b/src/v8-version.h
@@ -1,14 +1,1 @@
-// These macros weren't added until v8 version 4.4
-#ifndef V8_MAJOR_VERSION
-	#if NODE_MODULE_VERSION <= 11
-		#define V8_MAJOR_VERSION 3
-		#define V8_MINOR_VERSION 14
-	#elif V8_MAJOR_VERSION <= 14
-		#define V8_MAJOR_VERSION 3
-		#define V8_MINOR_VERSION 28
-	#else
-		#error v8 version macros missing
-	#endif
-#endif
-
 #define V8_AT_LEAST(major, minor) (V8_MAJOR_VERSION > major || (V8_MAJOR_VERSION == major && V8_MINOR_VERSION >= minor))

--- a/test.js
+++ b/test.js
@@ -11,11 +11,6 @@ function runTest(test, cb) {
 	}
 	env.NODE_PATH = __dirname;
 	var args = [];
-	if (process.versions.modules >= 57 && process.versions.modules < 59) {
-		// Node v8 requires forcing async hook checks. In Node v9 (>=59) and beyond,
-		// async hooks checks are on by default (and the param no longer exists).
-		args.push('--force-async-hooks-checks');
-	}
 	args.push(path.join('test', test));
 	var proc = spawn(process.execPath, args, { env: env });
 	proc.stdout.setEncoding('utf8');

--- a/test/async-hooks.js
+++ b/test/async-hooks.js
@@ -1,9 +1,5 @@
 'use strict';
-// This test must be run with --force-async-hooks-checks
-if (process.versions.modules < 57) {
-	console.log('pass');
-	return;
-}
+
 const { AsyncResource } = require('async_hooks');
 const Fiber = require('fibers');
 
@@ -13,15 +9,7 @@ class TestResource extends AsyncResource {
 	}
 
 	run(cb) {
-		// In the v8 API, only emitBefore() and emitAfter() are available
-		if (process.versions.modules < 59) {
-			this.emitBefore();
-			cb();
-			this.emitAfter();
-		} else {
-			// In v9 and higher, emitBefore() and emitAfter() are deperecated in favor of runInAsyncScope().
-			this.runInAsyncScope(cb);
-		}
+		this.runInAsyncScope(cb);
 	}
 }
 

--- a/test/cleanup.js
+++ b/test/cleanup.js
@@ -1,49 +1,42 @@
 "use strict";
 var Fiber = require('fibers');
 Fiber.poolSize = 100;
-let v8 = /^([0-9]+)\.([0-9]+)/.exec(process.versions.v8);
-if (v8[1] > 4 || (v8[1] == 4 && v8[2] >= 10)) {
 
-	// Vague benchmark of fiber performance, lower is better
-	function bench() {
-		var d = new Date;
-		for (var ii = 0; ii < 100; ++ii) {
-			var fibers = [];
-			for (var jj = 0; jj < Fiber.poolSize; ++jj) {
-				var fiber = Fiber(function() {
-					Fiber.yield();
-				});
-				fiber.run();
-				fibers.push(fiber);
-			}
-			fibers.map(function(fiber) {
-				fiber.run();
+// Vague benchmark of fiber performance, lower is better
+function bench() {
+	var d = new Date;
+	for (var ii = 0; ii < 100; ++ii) {
+		var fibers = [];
+		for (var jj = 0; jj < Fiber.poolSize; ++jj) {
+			var fiber = Fiber(function() {
+				Fiber.yield();
 			});
+			fiber.run();
+			fibers.push(fiber);
 		}
-		return new Date - d;
-	}
-
-	// Run initial benchmark
-	var ts1 = Math.min(bench(), bench());
-
-	// Dirty up isolate list
-	var fibers = [];
-	for (var ii = 0; ii < Fiber.poolSize + 1000; ++ii) {
-		let fiber = Fiber(function() {
-			Fiber.yield();
+		fibers.map(function(fiber) {
+			fiber.run();
 		});
-		fiber.run();
-		fibers.push(fiber);
 	}
-	fibers.map(function(fiber) {
-		fiber.run();
-	});
-
-	// Test again
-	var ts2 = Math.min(bench(), bench());
-	console.log(ts1 * 2 < ts2 ? 'fail' : 'pass');
-} else {
-
-	// Feature is not supported
-	console.log('pass');
+	return new Date - d;
 }
+
+// Run initial benchmark
+var ts1 = Math.min(bench(), bench());
+
+// Dirty up isolate list
+var fibers = [];
+for (var ii = 0; ii < Fiber.poolSize + 1000; ++ii) {
+	let fiber = Fiber(function() {
+		Fiber.yield();
+	});
+	fiber.run();
+	fibers.push(fiber);
+}
+fibers.map(function(fiber) {
+	fiber.run();
+});
+
+// Test again
+var ts2 = Math.min(bench(), bench());
+console.log(ts1 * 2 < ts2 ? 'fail' : 'pass');


### PR DESCRIPTION
Remove legacy V8 API support and cleanup code

- Remove support for older V8 versions (pre v8.4)
- Remove Electron-specific build configuration
- Remove Node.js v0.10.x compatibility code
- Remove async hooks compatibility code for Node.js v8/v9
- Remove version-specific workarounds and conditionals
- Bump version to 5.1.0

The codebase now requires modern V8/Node.js versions and removes years of accumulated compatibility layers.